### PR TITLE
Update Mac script

### DIFF
--- a/reproduce_mac.sh
+++ b/reproduce_mac.sh
@@ -12,11 +12,7 @@ if [ $(id -u) != 0 ]; then
     exit 1
 fi
 
-if [ $SUDO_USER ]; then
-    real_user=$SUDO_USER
-else
-    real_user=$(whoami)
-fi
+real_user=$SUDO_USER
 
 # Download and data
 sudo -u $real_user brew install git-lfs

--- a/reproduce_mac.sh
+++ b/reproduce_mac.sh
@@ -1,49 +1,67 @@
+#!/bin/sh
+
 # Requires Python version Python 3.9.5
 # Execute the following
 
+# Change this to where your Python 3.9.5 is.
+PYTHON=/Library/Frameworks/Python.framework/Versions/3.9/bin/python3
+
+# ref: https://askubuntu.com/questions/425754/how-do-i-run-a-sudo-command-inside-a-script
+if [ $(id -u) != 0 ]; then
+    echo "Please run this script as root."
+    exit 1
+fi
+
+if [ $SUDO_USER ]; then
+    real_user=$SUDO_USER
+else
+    real_user=$(whoami)
+fi
+
 # Download and data
-brew install git-lfs
-git lfs install
-git lfs pull --include=data.zip
-unzip data.zip
-rm -rf __MACOSX/
+sudo -u $real_user brew install git-lfs
+sudo -u $real_user git lfs install
+sudo -u $real_user git lfs pull --include=data.zip
+sudo -u $real_user unzip data.zip
+sudo -u $real_user find . -name "__MACOSX" -type d  # Recursively delete __MACOSX directories.
 
 # Install texlive
-brew install texlive
+sudo -u $real_user brew install texlive
 
 # Install baselines
-brew install cmake
+sudo -u $real_user brew install cmake
 cd Baseline/PCA-CD/Libraries/
-tar -xf libpca-1.2.11.tar.gz
-tar -xf armadillo-4.200.0.tar.gz 
+sudo -u $real_user tar -xf libpca-1.2.11.tar.gz
+sudo -u $real_user tar -xf armadillo-4.200.0.tar.gz
 cd armadillo-4.200.0
-cmake .
-sudo make install
-cmake .
-sudo make install
+sudo -u $real_user cmake .
+make install
+sudo -u $real_user cmake .
+make install
 cd ../libpca-1.2.11
-sudo sh install.sh
+sh install.sh
 cd ../../ChangeDetection/
-sudo make
-
+make
 
 # Create virtual environment and install dependencies
 cd ../../..
 
-# Change the line below to point out to the location where python3 is installed
-virtualenv --python=/Library/Frameworks/Python.framework/Versions/3.9/bin/python3 venv
-source ./venv/bin/activate
-sudo ./venv/bin/pip install matplotlib==3.5.0
-sudo ./venv/bin/pip install scikit-learn==1.0.1
-sudo ./venv/bin/pip install -e DataInsights
+# ref: https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script
+if ! command -v virtualenv &> /dev/null
+then
+    sudo -u $real_user $PYTHON -m venv venv
+else
+    sudo -u $real_user virtualenv --python=$PYTHON venv
+fi
+sudo -s -u $real_user ./venv/bin/pip install matplotlib==3.5.0 scikit-learn==1.0.1
+sudo -s -u $real_user ./venv/bin/pip install -e DataInsights
 
 # Generate plots and tables
-sudo mkdir Plots
-sudo ./venv/bin/python Figure_4.py
-sudo ./venv/bin/python Figure_5.py
-sudo ./venv/bin/python Figure_6_a.py
-sudo ./venv/bin/python Figure_6_b.py
-sudo ./venv/bin/python Figure_6_c.py
-sudo ./venv/bin/python Figure_7.py
-sudo ./venv/bin/python Figure_8.py
-
+sudo -u $real_user mkdir Plots
+./venv/bin/python Figure_4.py
+./venv/bin/python Figure_5.py
+./venv/bin/python Figure_6_a.py
+./venv/bin/python Figure_6_b.py
+./venv/bin/python Figure_6_c.py
+./venv/bin/python Figure_7.py
+./venv/bin/python Figure_8.py

--- a/reproduce_mac.sh
+++ b/reproduce_mac.sh
@@ -6,6 +6,9 @@
 # Change this to where your Python 3.9.5 is.
 PYTHON=/Library/Frameworks/Python.framework/Versions/3.9/bin/python3
 
+# Print the commands.
+set -x
+
 # ref: https://askubuntu.com/questions/425754/how-do-i-run-a-sudo-command-inside-a-script
 if [ $(id -u) != 0 ]; then
     echo "Please run this script as root."
@@ -18,7 +21,7 @@ real_user=$SUDO_USER
 sudo -u $real_user brew install git-lfs
 sudo -u $real_user git lfs install
 sudo -u $real_user git lfs pull --include=data.zip
-sudo -u $real_user unzip data.zip
+sudo -u $real_user unzip -f data.zip
 sudo -u $real_user find . -name "__MACOSX" -type d  # Recursively delete __MACOSX directories.
 
 # Install texlive
@@ -39,6 +42,9 @@ sh install.sh
 cd ../../ChangeDetection/
 make
 
+# We don't want to fail from this point onward.
+set -e
+
 # Create virtual environment and install dependencies
 cd ../../..
 
@@ -53,7 +59,7 @@ sudo -s -u $real_user ./venv/bin/pip install matplotlib==3.5.0 scikit-learn==1.0
 sudo -s -u $real_user ./venv/bin/pip install -e DataInsights
 
 # Generate plots and tables
-sudo -u $real_user mkdir Plots
+sudo -u $real_user mkdir -p Plots
 ./venv/bin/python Figure_4.py
 ./venv/bin/python Figure_5.py
 ./venv/bin/python Figure_6_a.py


### PR DESCRIPTION
This pull request adds a few things to the shell script for Mac.

In particular:

- Adds a hash bang for sh
- Recursively deletes the `__MACOSX` directories from the archive
- Allows users to specify the location of Python in the first few lines
- Prevents running brew as root
- Removes `source` because sudo doesn't have shell
- Uses the built-in Python venv module if `virtualenv` doesn't exist
- Adds `set -ex` at some points to help visualize what's happening and exiting when something fails